### PR TITLE
Remove unnecessary methods from LectorService

### DIFF
--- a/src/main/java/ua/yatsergray/university/management/system/service/LectorService.java
+++ b/src/main/java/ua/yatsergray/university/management/system/service/LectorService.java
@@ -1,16 +1,10 @@
 package ua.yatsergray.university.management.system.service;
 
 import ua.yatsergray.university.management.system.domain.dto.LectorDTO;
-import ua.yatsergray.university.management.system.domain.type.DegreeType;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface LectorService {
-
-    Optional<LectorDTO> getHeadByDepartmentName(String departmentName);
-
-    List<LectorDTO> getAllByDegreeTypeAndDepartmentName(DegreeType lectorDegreeType, String departmentName);
 
     List<LectorDTO> getAllLectorsByNameTemplate(String lectorNameTemplate);
 }

--- a/src/main/java/ua/yatsergray/university/management/system/service/impl/LectorServiceImpl.java
+++ b/src/main/java/ua/yatsergray/university/management/system/service/impl/LectorServiceImpl.java
@@ -4,13 +4,11 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ua.yatsergray.university.management.system.domain.dto.LectorDTO;
-import ua.yatsergray.university.management.system.domain.type.DegreeType;
 import ua.yatsergray.university.management.system.mapper.LectorMapper;
 import ua.yatsergray.university.management.system.repository.LectorRepository;
 import ua.yatsergray.university.management.system.service.LectorService;
 
 import java.util.List;
-import java.util.Optional;
 
 @Transactional
 @Service
@@ -22,16 +20,6 @@ public class LectorServiceImpl implements LectorService {
     public LectorServiceImpl(LectorMapper lectorMapper, LectorRepository lectorRepository) {
         this.lectorMapper = lectorMapper;
         this.lectorRepository = lectorRepository;
-    }
-
-    @Override
-    public Optional<LectorDTO> getHeadByDepartmentName(String departmentName) {
-        return lectorRepository.findHeadByDepartmentName(departmentName).map(lectorMapper::mapToLectorDTO);
-    }
-
-    @Override
-    public List<LectorDTO> getAllByDegreeTypeAndDepartmentName(DegreeType lectorDegreeType, String departmentName) {
-        return lectorMapper.mapAllToLectorDTOList(lectorRepository.findAllByDegreeTypeAndDepartmentName(lectorDegreeType, departmentName));
     }
 
     @Override


### PR DESCRIPTION
This pull request simplifies the LectorService interface and its implementation by removing redundant methods that are no longer needed. The changes aim to streamline the service's responsibilities and improve code maintainability.
Removed Methods from LectorService Interface:
- Optional<LectorDTO> getHeadByDepartmentName(String departmentName)
- List<LectorDTO> getAllByDegreeTypeAndDepartmentName(DegreeType lectorDegreeType, String departmentName)